### PR TITLE
Remove code for SKL versions < 1

### DIFF
--- a/nimble/core/interfaces/scikit_learn_interface.py
+++ b/nimble/core/interfaces/scikit_learn_interface.py
@@ -1,5 +1,5 @@
 """
-Relies on being scikit-learn 0.19 or above
+Relies on being scikit-learn 1.0 or above
 
 TODO: multinomialHMM requires special input processing for obs param
 """
@@ -359,15 +359,8 @@ class SciKitLearn(_SciKitLearnAPI):
             warnings.simplefilter('ignore', (DeprecationWarning,
                                              FutureWarning))
             with mock.patch('pkgutil.walk_packages', mockWalkPackages):
-                try:
-                    utils = modifyImportPathAndImport('sklearn',
-                                                      'sklearn.utils')
-                    estimatorDict = utils.all_estimators()
-                except AttributeError: # version < 0.22
-                    utils = modifyImportPathAndImport('sklearn',
-                                                      'sklearn.utils.testing')
-                    estimatorDict = utils.all_estimators(
-                        include_dont_test=True)
+                utils = modifyImportPathAndImport('sklearn', 'sklearn.utils')
+                estimatorDict = utils.all_estimators()
 
             self.allEstimators = {}
             for name, obj in estimatorDict:


### PR DESCRIPTION
I recalled there being some code in the SciKitLearn interface that related to earlier versions. This actually wasn't what I was thinking of, that must have been removed in the past, but there was one section that was only there to support earlier versions.